### PR TITLE
Fixes for May 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ Build
       
 and run
       
-    java -jar target/scala-2.12/filmweb-to-imdb-assembly-*.jar $TMDB_API_KEY $IMDB_COOKIE_ID $FILMWEB_LOGIN $FILMWEB_PASSWORD
+    java -jar target/scala-2.12/filmweb-to-imdb-assembly-*.jar $TMDB_API_KEY $IMDB_COOKIE_ID $FILMWEB_LOGIN $FILMWEB_PASSWORD $OMDB_API_KEY
 
 Requirements
 ------------
 - [Filmweb.pl](http://www.filmweb.pl/) account credentials. Logging with Facebook or Google+ accounts is not supported.
 - [IMDb](http://www.imdb.com/) session cookie id. Log into IMDb with your browser and get assigned session cookied id.
 - [TMDb](https://www.themoviedb.org/) API key. Read [FAQ](https://www.themoviedb.org/faq/api) to see how to apply for a key.
+- [OMDb](https://omdbapi.com/) API key. Generate [here](http://omdbapi.com/apikey.aspx).
 
 Limitations
 -----------

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ handles better slight variations of the same titles.
 Once IMDb ID of the movie is found, then movie rating is set in IMDb with use of private API. IMDb expects rates ranging
 from 1 to 10. Therefore, Filmweb's 0 rates (watched, but not rated) are being ignored. 
 
-In the end program will list all title ratings from Filmweb for which IMDb IDs could not be found. 
+In the end program will list all title ratings from Filmweb for which IMDb IDs could not be found, as well as those for which it failed to copy ratings for other reasons.
 
 Build and run
 -------------
@@ -44,4 +44,5 @@ Known Issues
 ------------
 - Release years can differ between Filmweb and IMDb databases; especially for Polish productions. Better heuristic could be
 implemented, but currently these cases are ignored and listed as not found in IMDb.
-- If a movie has a game with a title same as in Filmweb database, then the game might be rated.  
+- If a movie has a game with a title same as in Filmweb database, then the game might be rated.
+- If a movie has multiple IMDb IDs, its rating may not be copied.

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ libraryDependencies ++= Seq(
   "com.google.code.gson" % "gson" % "2.5",
   "com.google.guava" % "guava" % "19.0",
   // IMDb API
-  "com.omertron" % "API-OMDB" % "1.2",
+  "com.omertron" % "API-OMDB" % "1.5",
   "com.uwetrottmann.tmdb2" % "tmdb-java" % "1.5.0",
   "org.scalaj" %% "scalaj-http" % "2.3.0",
   // tests

--- a/src/main/scala/info/ganczarek/CopyFilmwebRatesToImdbApp.scala
+++ b/src/main/scala/info/ganczarek/CopyFilmwebRatesToImdbApp.scala
@@ -10,9 +10,10 @@ object CopyFilmwebRatesToImdbApp {
     val imdbCookieId = args(1)
     val filmwebLogin = args(2)
     val filmwebPassword = args(3)
+    val omdbApiKey = args(4)
 
     val filmwebClient = FilmwebClient(filmwebLogin, filmwebPassword)
-    val imdbClient = ImdbClient(imdbCookieId, tmdbApiKey)
+    val imdbClient = ImdbClient(imdbCookieId, tmdbApiKey, omdbApiKey)
 
     val notFoundMovieRates = imdbClient.submitMovieRates(filmwebClient.userRates()).toList
     println("Movies that could not be found in IMDb database:")

--- a/src/main/scala/info/ganczarek/imdb/ImdbClient.scala
+++ b/src/main/scala/info/ganczarek/imdb/ImdbClient.scala
@@ -26,7 +26,15 @@ class ImdbClient(cookieId: String, omdbApi: OmdbApi, tmdbClient: TmdbClient) {
       .map(movieRate => (getImdbIdForItemRate(movieRate), movieRate))
 
     movieRatesWithImdbId.flatMap {
-        case (Some(imdbId), movieRate) => submitRating(imdbId, movieRate); None
+        case (Some(imdbId), movieRate) => (
+        if( getAuthToken(cookieId, imdbId).isEmpty() ) {
+            logger.warn("Failed to fetch auth token for {}", movieRate)
+            Some(movieRate)
+        }
+        else {
+            submitRating(imdbId, movieRate)
+            None
+        })
         case (None, movieRate) => logger.warn("Failed to find IMDB ID for {}", movieRate); Some(movieRate)
       }.toSeq
   }

--- a/src/main/scala/info/ganczarek/imdb/ImdbClient.scala
+++ b/src/main/scala/info/ganczarek/imdb/ImdbClient.scala
@@ -13,7 +13,7 @@ object ImdbClient {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
-  def apply(imdbCookieId: String, tmdbApiKey: String): ImdbClient = new ImdbClient(imdbCookieId, new OmdbApi(), TmdbClient(tmdbApiKey))
+  def apply(imdbCookieId: String, tmdbApiKey: String, omdbApiKey: String): ImdbClient = new ImdbClient(imdbCookieId, new OmdbApi(omdbApiKey), TmdbClient(tmdbApiKey))
 
 }
 

--- a/src/main/scala/info/ganczarek/imdb/TmdbClient.scala
+++ b/src/main/scala/info/ganczarek/imdb/TmdbClient.scala
@@ -17,7 +17,9 @@ class TmdbClient(tmdb: Tmdb) {
     (itemRate match {
       case movieRate: MovieRate => getImdbIdForMovie(movieRate)
       case seriesRate: SeriesRate => getImdbIdForSeries(seriesRate)
-    }).filter(_.startsWith("tt"))
+    })
+    .filter(_ != null)
+    .filter(_.startsWith("tt"))
   }
 
   private def getImdbIdForMovie(movieRate: MovieRate): Option[String] = {

--- a/src/main/scala/info/ganczarek/imdb/TmdbClient.scala
+++ b/src/main/scala/info/ganczarek/imdb/TmdbClient.scala
@@ -8,6 +8,7 @@ import scala.collection.JavaConverters._
 object TmdbClient {
 
   def apply(tmdbApiKey: String): TmdbClient = new TmdbClient(new Tmdb(tmdbApiKey))
+
 }
 
 class TmdbClient(tmdb: Tmdb) {


### PR DESCRIPTION
1. OMDb API now needs a key.
2. Auth token did not fetch properly for me - it contained more elements than needed, and thus failed to submit ratings. Fixed.
3. An exception when movie entry in TMDb yields null string is fixed, eg https://www.themoviedb.org/movie/456406-ivetka-a-hora .
4. Sometimes a movie has two IMDb IDs (e.g. https://www.imdb.com/title/tt1754691/ , https://www.imdb.com/title/tt1723118/ ). One of the IDs is just a redirect. In such a case, the auth token is not fetched properly. Such movies are listed as "not found" even though there should be some workaround.